### PR TITLE
feat: add WithBaseURL func to mock base URL for testing

### DIFF
--- a/deepl.go
+++ b/deepl.go
@@ -90,6 +90,14 @@ func WithRetryPolicy(maxRetryAttempts, maxDelaySeconds int) Option {
 	}
 }
 
+// WithBaseURL returns an Option that sets a custom base URL for the client.
+// This is particularly useful for testing with mock servers or using alternative API endpoints.
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) {
+		c.baseURL = baseURL
+	}
+}
+
 // WithTrace returns an Option that enables HTTP request and response logging for debugging.
 func WithTrace() Option {
 	return func(c *Client) {

--- a/deepl_test.go
+++ b/deepl_test.go
@@ -82,6 +82,32 @@ func TestWithUserAgent(t *testing.T) {
 	}
 }
 
+func TestWithBaseURL(t *testing.T) {
+	customBaseURL := "http://localhost:8080"
+	client := NewClient("api-key", WithBaseURL(customBaseURL))
+
+	if client.baseURL != customBaseURL {
+		t.Errorf("expected baseURL '%s', got %s", customBaseURL, client.baseURL)
+	}
+}
+
+func TestWithBaseURL_OverridesDefaultBehavior(t *testing.T) {
+	// Test that WithBaseURL overrides the default API key based URL selection
+	customBaseURL := "https://custom-api.example.com"
+
+	// Free API key should normally use baseURLFree, but WithBaseURL should override it
+	freeKeyClient := NewClient("free-api-key:fx", WithBaseURL(customBaseURL))
+	if freeKeyClient.baseURL != customBaseURL {
+		t.Errorf("WithBaseURL should override free API key URL, expected '%s', got %s", customBaseURL, freeKeyClient.baseURL)
+	}
+
+	// Regular API key should normally use baseURL, but WithBaseURL should override it
+	regularKeyClient := NewClient("regular-api-key", WithBaseURL(customBaseURL))
+	if regularKeyClient.baseURL != customBaseURL {
+		t.Errorf("WithBaseURL should override regular API key URL, expected '%s', got %s", customBaseURL, regularKeyClient.baseURL)
+	}
+}
+
 func TestWithProxy(t *testing.T) {
 	proxyUrl, _ := url.Parse("http://localhost:8080")
 	client := NewClient("api-key", WithProxy(*proxyUrl))


### PR DESCRIPTION
This PR simply adds a function that sets a custom base URL to the Option (`WithBaseURL`).

Makes it useful for testing with mock servers or using alternative API endpoints.

> [!NOTE]
> This PR is a preparation for the next/upcoming PR that I'm planning which implements an End-to-End-like testing using the [official API mock server](https://github.com/DeepLcom/deepl-mock) and docker. I will PR them as soon as this PR gets approved and merged.