### PR TITLE
feat: #4 E2E test env using mock server

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,35 @@
+name: e2e
+
+permissions: {} # no need any permissions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e-test:
+    name: E2E Test with Mock Server
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 'stable'
+          check-latest: true
+
+      - name: Start DeepL Mock Server
+        run: docker compose up deepl-mock -d
+
+      - name: Run E2E Tests
+        run: docker compose run --rm deepl-test
+
+      - name: Stop and Clean Up
+        if: always()
+        run: docker compose down --remove-orphans

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,11 +18,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v5
 
-      - name: Install Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: 'stable'
-          check-latest: true
+      - name: Pull and Build Docker Images
+        run: |
+          docker compose pull
+          docker compose build
 
       - name: Start DeepL Mock Server
         run: docker compose up deepl-mock -d

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: 'stable'
           check-latest: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,5 +54,5 @@ jobs:
         continue-on-error: true
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-          file: ./coverage.txt
+          files: ./coverage.txt
           fail_ci_if_error: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           check-latest: true
@@ -50,7 +50,7 @@ jobs:
         run: go test -v -count=1 -race -shuffle=on -coverprofile=coverage.txt ./...
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         continue-on-error: true
         with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 # IDE
 .idea
 test/
+
+# Coverage
+coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+.PHONY: help test test-unit test-e2e test-all mock-up mock-down clean fmt vet
+
+# Default target
+help:
+	@echo "Available targets:"
+	@echo "  test           - Run unit tests only"
+	@echo "  test-unit      - Same as test"
+	@echo "  test-e2e       - Run E2E tests with mock server"
+	@echo "  test-all       - Run both unit and E2E tests"
+	@echo "  mock-up        - Start DeepL mock server"
+	@echo "  mock-down      - Stop and clean up Docker containers"
+	@echo "  clean          - Clean up test artifacts and Docker containers"
+	@echo "  fmt            - Run go fmt on all files"
+	@echo "  vet            - Run go vet on all files"
+
+# Run unit tests only (no E2E tests)
+test: test-unit
+
+test-unit:
+	go test -v -count=1 -race -shuffle=on -coverprofile=coverage.txt ./...
+
+# Run E2E tests with mock server
+test-e2e:
+	@echo "Starting DeepL mock server..."
+	docker compose up deepl-mock -d
+	@echo "Running E2E tests..."
+	docker compose run --rm deepl-test
+	@echo "Cleaning up..."
+	docker compose down --remove-orphans
+
+# Run all tests (unit + E2E)
+test-all: test-unit test-e2e
+
+# Start mock server
+mock-up:
+	docker compose up deepl-mock -d
+
+# Stop mock server
+mock-down:
+	docker compose down --remove-orphans
+
+# Clean up
+clean: mock-down
+	rm -f coverage.txt
+
+# Format code
+fmt:
+	gofmt -s -w .
+
+# Vet code
+vet:
+	go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<!-- markdownlint-disable MD041 MD033 --><div align="center">
 
 [![deepl-go][repo_logo_img]][repo_url]
 
@@ -10,6 +10,7 @@
 [![Lisence: MIT][license_badge]][license_url]
 
 `deepl-go` is an unofficial Go client library for the [DeepL translation API][deepl_api_docs]. It enables developers to integrate DeepL's powerful translation services into their Go applications effortlessly.
+
 </div>
 
 ---
@@ -46,12 +47,17 @@ go get github.com/lkretschmer/deepl-go
 ## 🚀 Usage
 
 ### Creating a Client
+
 Create a new DeepL client by providing your API key:
+
 ```go
 client := deepl.NewClient("your_api_key_here")
 ```
+
 ### Translating Text
+
 Translate a single string to a target language:
+
 ```go
 translation, err := client.TranslateText("Hello, world!", "DE")
 if err != nil {
@@ -62,16 +68,70 @@ fmt.Println("Translated text:", translation.Text)
 
 ---
 
+## 🧪 Testing
+
+### Running Unit Tests
+
+Run the standard unit tests:
+
+```bash
+go test -v ./...
+```
+
+### Running E2E Tests
+
+This project includes End-to-End (E2E) tests that use the [DeepL Mock Server](https://github.com/DeepLcom/deepl-mock) to simulate real API interactions without requiring an actual API key.
+
+- Requirements
+  - Docker
+  - Docker Compose
+
+#### Running E2E and Unit Tests Together
+
+```bash
+# Start the mock server
+docker compose up deepl-mock -d
+
+# Run all tests (unit + E2E)
+docker compose run --rm deepl-test
+
+# Clean up
+docker compose down --remove-orphans
+```
+
+Alternatively, if you have `make` installed:
+
+```bash
+make test-all
+```
+
+#### Running E2E Tests Locally Only
+
+```bash
+# Start the mock server
+docker compose up deepl-mock -d
+
+# Run E2E tests only
+go test -tags=e2e -v ./...
+
+# Clean up
+docker compose down --remove-orphans
+```
+
+The E2E tests are automatically run in GitHub Actions CI for all pull requests and pushes to the main branch.
+
+---
+
 ## 📄 License
+
 This project is licensed under the MIT License.
 See the [LICENSE][license_url] file for details.
 
 ---
 
 ## ⚠️ Disclaimer
+
 This client library is not an official DeepL product. For official documentation and terms, please visit [DeepL API][deepl_api_docs].
-
-
 
 [repo_url]: https://github.com/lkretschmer/deepl-go
 [repo_logo_img]: https://raw.githubusercontent.com/lkretschmer/deepl-go/refs/heads/main/.github/logo.svg

--- a/deepl_e2e_test.go
+++ b/deepl_e2e_test.go
@@ -2,6 +2,7 @@
 // +build e2e
 
 // End-to-End (E2E) tests for the DeepL Go client library.
+// (See: https://github.com/lkretschmer/deepl-go/issues/4 )
 //
 // These tests use the DeepL Mock server (https://github.com/DeepLcom/deepl-mock)
 // to simulate real DeepL API interactions without requiring actual API credentials.

--- a/deepl_e2e_test.go
+++ b/deepl_e2e_test.go
@@ -1,0 +1,272 @@
+//go:build e2e
+// +build e2e
+
+// End-to-End (E2E) tests for the DeepL Go client library.
+//
+// These tests use the DeepL Mock server (https://github.com/DeepLcom/deepl-mock)
+// to simulate real DeepL API interactions without requiring actual API credentials
+// or consuming API quota.
+//
+// DOCKER COMPOSE WORKFLOW:
+//
+// 1. Spawn the DeepL Mock server:
+//    docker compose up deepl-mock -d
+//
+//    This starts the mock server container in detached mode. The mock server
+//    provides the same API endpoints as the real DeepL API but with limited
+//    functionality suitable for testing (e.g., translates "Hello, world!" to "陽子ビーム").
+//
+// 2. Run the E2E test container and check exit status:
+//    docker compose run --rm deepl-test
+//    echo $?  # Should output "0" if all tests pass
+//
+//    The test container runs `go test -tags=e2e ./...` and exits with status 0
+//    on success or non-zero on failure. The --rm flag automatically removes
+//    the test container after execution.
+//
+// 3. Clean up all containers (including orphans):
+//    docker compose down --remove-orphans
+//
+//    This stops and removes all containers created by docker compose, including
+//    any orphaned containers from previous test runs.
+//
+// ONE-LINER FOR FULL WORKFLOW:
+//    docker compose up deepl-mock -d && \
+//    docker compose run --rm deepl-test && \
+//    echo "Tests passed!" || echo "Tests failed!" && \
+//    docker compose down --remove-orphans
+//
+// ALTERNATIVE: Direct Go test execution (requires mock server running):
+//    go test -tags=e2e -v ./...
+
+package deepl
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Mock server test credentials
+	mockAPIKey = "mock-api-key"
+
+	// Test timeouts
+	testTimeout = 30 * time.Second
+)
+
+// getMockServerURL returns the mock server URL from environment variable or default
+func getMockServerURL() string {
+	if url := os.Getenv("DEEPL_SERVER_URL"); url != "" {
+		return url
+	}
+	return "http://localhost:3000"
+}
+
+// WithBaseURL returns an Option that sets a custom base URL for the client
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) {
+		c.baseURL = baseURL
+	}
+}
+
+// waitForMockServer waits for the mock server to be ready
+func waitForMockServer(t *testing.T, serverURL string) {
+	t.Helper()
+
+	client := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("Mock server did not become ready in time")
+		case <-ticker.C:
+			req, err := http.NewRequestWithContext(ctx, "GET", serverURL+"/v2/usage?auth_key=smoke_test", nil)
+			require.NoError(t, err)
+
+			req.Header.Set("User-Agent", "deepl-go-e2e-test")
+
+			resp, err := client.Do(req)
+			if err == nil && resp.StatusCode == 200 {
+				resp.Body.Close()
+				return
+			}
+			if resp != nil {
+				resp.Body.Close()
+			}
+		}
+	}
+}
+
+func TestE2E_MockServerHealth(t *testing.T) {
+	serverURL := getMockServerURL()
+
+	// Wait for mock server to be ready
+	waitForMockServer(t, serverURL)
+
+	// Create HTTP client for direct API calls
+	client := &http.Client{Timeout: 10 * time.Second}
+
+	// Test health endpoint
+	req, err := http.NewRequest("GET", serverURL+"/v2/usage?auth_key=smoke_test", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("User-Agent", "deepl-go-e2e-test")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode, "Mock server should be healthy")
+}
+
+func TestE2E_DeepLClient_GetUsage(t *testing.T) {
+	serverURL := getMockServerURL()
+
+	// Wait for mock server to be ready
+	waitForMockServer(t, serverURL)
+
+	// Create DeepL client with mock server URL
+	client := NewClient(mockAPIKey,
+		WithBaseURL(serverURL),
+		WithUserAgent("deepl-go-e2e-test"),
+	)
+
+	// Test GetUsage
+	usage, err := client.GetUsage()
+	require.NoError(t, err, "GetUsage should succeed with mock server")
+
+	assert.NotNil(t, usage, "Usage response should not be nil")
+
+	// Mock server should return some usage data
+	t.Logf("Usage response: CharacterCount=%d, CharacterLimit=%d",
+		usage.CharacterCount, usage.CharacterLimit)
+}
+
+func TestE2E_DeepLClient_TranslateText(t *testing.T) {
+	serverURL := getMockServerURL()
+
+	// Wait for mock server to be ready
+	waitForMockServer(t, serverURL)
+
+	// Create DeepL client with mock server URL
+	client := NewClient(mockAPIKey,
+		WithBaseURL(serverURL),
+		WithUserAgent("deepl-go-e2e-test"),
+	)
+
+	// Test TranslateText
+	text := "Hello, world!"
+	targetLang := "JA"
+
+	translation, err := client.TranslateText(text, targetLang)
+	require.NoError(t, err, "TranslateText should succeed with mock server")
+
+	assert.NotNil(t, translation, "Should return a translation")
+	assert.NotEmpty(t, translation.Text, "Translation text should not be empty")
+	assert.NotEmpty(t, translation.DetectedSourceLanguage, "Should detect source language")
+
+	t.Logf("Translation: '%s' -> '%s'", text, translation.Text)
+}
+
+func TestE2E_DeepLClient_GetSupportedLanguages(t *testing.T) {
+	serverURL := getMockServerURL()
+
+	// Wait for mock server to be ready
+	waitForMockServer(t, serverURL)
+
+	// Create DeepL client with mock server URL
+	client := NewClient(mockAPIKey,
+		WithBaseURL(serverURL),
+		WithUserAgent("deepl-go-e2e-test"),
+	)
+
+	// Test GetSourceLanguages
+	sourceLangs, err := client.GetSourceLanguages()
+	require.NoError(t, err, "GetSourceLanguages should succeed")
+	assert.NotEmpty(t, sourceLangs, "Should return supported source languages")
+
+	// Test GetTargetLanguages
+	targetLangs, err := client.GetTargetLanguages()
+	require.NoError(t, err, "GetTargetLanguages should succeed")
+	assert.NotEmpty(t, targetLangs, "Should return supported target languages")
+
+	t.Logf("Found %d source languages and %d target languages",
+		len(sourceLangs), len(targetLangs))
+}
+
+func TestE2E_DeepLClient_ErrorHandling(t *testing.T) {
+	serverURL := getMockServerURL()
+
+	// Wait for mock server to be ready
+	waitForMockServer(t, serverURL)
+
+	// Test with various invalid scenarios
+	testCases := []struct {
+		name   string
+		apiKey string
+	}{
+		{"empty key", ""},
+		{"invalid literal", "invalid"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewClient(tc.apiKey,
+				WithBaseURL(serverURL),
+				WithUserAgent("deepl-go-e2e-test"),
+			)
+
+			// Test with invalid API key - may or may not return error depending on mock server behavior
+			usage, err := client.GetUsage()
+
+			// Log the result regardless
+			if err != nil {
+				t.Logf("API key '%s' returned error: %v", tc.apiKey, err)
+				assert.Contains(t, err.Error(), "HTTP", "Error should contain HTTP status information")
+			} else {
+				t.Logf("API key '%s' succeeded with usage: %+v", tc.apiKey, usage)
+				// Mock server may accept invalid keys for testing purposes
+				assert.NotNil(t, usage, "Usage response should not be nil")
+			}
+		})
+	}
+}
+
+func TestE2E_DeepLClient_WithProxy(t *testing.T) {
+	// Skip this test if proxy URL is not configured
+	proxyURL := os.Getenv("DEEPL_PROXY_URL")
+	if proxyURL == "" {
+		t.Skip("DEEPL_PROXY_URL not set, skipping proxy test")
+	}
+
+	serverURL := getMockServerURL()
+
+	// Wait for mock server to be ready
+	waitForMockServer(t, serverURL)
+
+	// Note: This test would need proper proxy setup in the mock server
+	// For now, we just verify that the proxy option doesn't break the client
+	client := NewClient(mockAPIKey,
+		WithBaseURL(serverURL),
+		WithUserAgent("deepl-go-e2e-test"),
+	)
+
+	// Basic functionality test with proxy configuration
+	usage, err := client.GetUsage()
+	require.NoError(t, err, "Should work even with proxy option configured")
+	assert.NotNil(t, usage, "Usage response should not be nil")
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  deepl-mock:
+    build: https://github.com/DeepLcom/deepl-mock.git
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+    container_name: deepl-mock
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/v2/usage?auth_key=smoke_test"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+
+  deepl-test:
+    image: golang:alpine
+    working_dir: /src
+    volumes:
+      - "./:/src"
+    environment:
+      - CGO_ENABLED=0
+      - DEEPL_SERVER_URL=http://deepl-mock:3000
+      - DEEPL_PROXY_URL=http://deepl-mock:3001
+    depends_on:
+      deepl-mock:
+        condition: service_healthy
+    command: go test -tags=e2e -v ./...


### PR DESCRIPTION
This PR features E2E tests to the CI using official API mock server.

- #4
- Requires `docker` which is installed by default in GitHub Actions's Ubuntu runner.
 
### How to test

```shellsession
$ # Spawn the mock server
$ docker compose up deepl-mock -d
[+] Running 2/2
 ✔ Network deepl-go_default  Created                                       0.0s 
 ✔ Container deepl-mock      Started                                       0.2s 

$ # Run tests (both usual unit tests and E2E tests)
$ docker compose run --rm deepl-test
[+] Creating 1/1
 ✔ Container deepl-mock  Running                                           0.0s 
**snip**
PASS
ok  	github.com/lkretschmer/deepl-go	6.148s

$ # Teardown the server
$ docker compose down --remove-orphans
[+] Running 2/2
 ✔ Container deepl-mock      Removed                                       0.3s 
 ✔ Network deepl-go_default  Removed                                       0.2s 
```

- Env info

```shellsession
$ docker --version        
Docker version 28.3.2, build 578ccf6
$ docker compose version
Docker Compose version v2.39.1-desktop.1
```
